### PR TITLE
[fix] time-zone 설정

### DIFF
--- a/server/src/main/java/com/web6/server/service/ReviewService.java
+++ b/server/src/main/java/com/web6/server/service/ReviewService.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -83,7 +84,7 @@ public class ReviewService {
         review.setWriter(writer);
         review.setContent(reviewRequestDTO.getContent());
         review.setGrade(reviewRequestDTO.getGrade());
-        review.setCreateDate(LocalDateTime.now());
+        review.setCreateDate(LocalDateTime.now(ZoneId.of("Asia/Seoul")));
         review.setEdit(false);
         review.setSpoiler(reviewRequestDTO.isSpoiler());
         review.setCommentsCount(0);

--- a/server/src/main/resources/application.yaml
+++ b/server/src/main/resources/application.yaml
@@ -8,6 +8,8 @@ jwt:
 #      port: 6379
 
 spring:
+  jackson:
+    time-zone: Asia/Seoul
   datasource:
     url: "jdbc:mariadb://svc.sel5.cloudtype.app:32171/netview"
     username: ${DB_USERNAME}


### PR DESCRIPTION
- 로컬에서는 리뷰/대댓글 등록 시, createDate가 올바르게 저장되었지만
- 배포된 서버에서는 실제 시간보다 이르게 저장되었음

-> 이를 yaml파일과 review를 post하는 과정에 time-zone 설정 추가해서 해결함