### PR TITLE
[feature] 로그인 연동을 위한 same-site 설정 추가

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -33,7 +33,6 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis' //휘발성 DB
 	testImplementation("org.assertj:assertj-core:3.22.0")
 	implementation group: 'org.javassist', name: 'javassist', version: '3.15.0-GA'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
@@ -49,6 +48,7 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+	implementation 'org.springframework.session:spring-session-core' //세션
 }
 
 tasks.named('test') {

--- a/server/src/main/java/com/web6/server/controller/SignUpController.java
+++ b/server/src/main/java/com/web6/server/controller/SignUpController.java
@@ -116,19 +116,19 @@ public class SignUpController {
     }
 
 
-    @PostMapping("/api/loginError")
+    /*@PostMapping("/api/loginError")
     public ApiResponse<Void> loginerror(){
         return new ApiResponse<>(false, "로그인에 실패하였습니다. 아이디와 비밀번호를 다시 입력해 주세요.", null);
-    } //loginError get이 true라는 뜻임 -> 로그인은 실패라는 뜻
+    } */
 
     @GetMapping("/logout-page")
     public ApiResponse<Void> logoutPage() {
         return new ApiResponse<>(true, "로그아웃 페이지", null);
     }
 
-    @GetMapping("/api/loginSuccess")
+    /*@GetMapping("/api/loginSuccess")
     public ApiResponse<Void> loginSuccess(){
         return new ApiResponse<>(true, "로그인 성공", null);
-    }
+    }*/
 
 }

--- a/server/src/main/java/com/web6/server/controller/loginHandler/CustomAuthenticationFailureHandler.java
+++ b/server/src/main/java/com/web6/server/controller/loginHandler/CustomAuthenticationFailureHandler.java
@@ -1,0 +1,53 @@
+package com.web6.server.controller.loginHandler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+
+import java.io.IOException;
+
+public class CustomAuthenticationFailureHandler implements AuthenticationFailureHandler {
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+
+        // 응답 데이터 생성
+        response.getWriter().write(objectMapper.writeValueAsString(new LoginResponse(false, "로그인 실패", null)));
+    }
+
+    static class LoginResponse {
+        private boolean success;
+        private String message;
+        private String sessionId;
+
+        public LoginResponse(boolean success, String message, String sessionId) {
+            this.success = success;
+            this.message = message;
+            this.sessionId = sessionId;
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+        public void setSuccess(boolean success) {
+            this.success = success;
+        }
+        public String getMessage() {
+            return message;
+        }
+        public void setMessage(String message) {
+            this.message = message;
+        }
+        public String getSessionId() {
+            return sessionId;
+        }
+        public void setSessionId(String sessionId) {
+            this.sessionId = sessionId;
+        }
+    }
+}

--- a/server/src/main/java/com/web6/server/controller/loginHandler/CustomAuthenticationSuccessHandler.java
+++ b/server/src/main/java/com/web6/server/controller/loginHandler/CustomAuthenticationSuccessHandler.java
@@ -1,0 +1,54 @@
+package com.web6.server.controller.loginHandler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+import java.io.IOException;
+
+public class CustomAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType("application/json;charset=UTF-8");
+
+        // 세션 ID를 포함한 응답 데이터 생성
+        String sessionId = request.getSession().getId();
+        response.getWriter().write(objectMapper.writeValueAsString(new LoginResponse(true, "로그인 성공", sessionId)));
+    }
+
+    static class LoginResponse {
+        private boolean success;
+        private String message;
+        private String sessionId;
+
+        public LoginResponse(boolean success, String message, String sessionId) {
+            this.success = success;
+            this.message = message;
+            this.sessionId = sessionId;
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+        public void setSuccess(boolean success) {
+            this.success = success;
+        }
+        public String getMessage() {
+            return message;
+        }
+        public void setMessage(String message) {
+            this.message = message;
+        }
+        public String getSessionId() {
+            return sessionId;
+        }
+        public void setSessionId(String sessionId) {
+            this.sessionId = sessionId;
+        }
+    }
+}

--- a/server/src/main/resources/application.yaml
+++ b/server/src/main/resources/application.yaml
@@ -54,6 +54,9 @@ spring:
 server:
   servlet:
     session:
+      cookie:
+        same-site: none
+        secure: true
       timeout: 90m
     encoding:
       charset: UTF-8


### PR DESCRIPTION
로그인 연동이 안됐던 이유는

원래는 브라우저가 자동으로 서버가 발급해준 세션아이디를 저장함

서버에서 발급한 세션아이디를 https로 프론트에게 보냈는데
프론트가 로컬에서 테스트하면서 도메인이 https->http로 설정되어 있었고,

기본 보안설정??(same-site) 때문에 http가 세션아이디에 접근을 못하도록 막아놔서 세션아이디를 브라우저가 저장 못하고 있었음

그래서 지금 임의로 서버에서 기본 보안설정을 꺼놓는 코드(same-site : none)를 작성했고,
지금은 그래서 프론트 http에서 세션을 접근할 수 있는 거라고 예상하고 있음

더 공부해서 근본적인 원인과 완벽한 해결방법을 찾을 수 있도록 할 예정.